### PR TITLE
addCommandHadler 바인딩 구문 제거

### DIFF
--- a/src/components/Terminal.js
+++ b/src/components/Terminal.js
@@ -11,7 +11,6 @@ class Terminal extends React.Component {
             result: '',
             periods: 1
         };
-        this.addCommandHandler = this.addCommandHandler.bind(this)
     };
 
     addCommandHandler = () => {


### PR DESCRIPTION
`addCommandHandler`가 화살표 함수로 구성된 public class field라서 따로 this를 바인딩해주지 않아도 될 것 같아요 :)